### PR TITLE
LSA with outer product of QA

### DIFF
--- a/bapred/Main.py
+++ b/bapred/Main.py
@@ -18,7 +18,30 @@ def dump_model(model, name, data_dir):
     with open('{}{}.pkl'.format(data_dir, name), 'wb') as f:
         pickle.dump(model, f)
 
+
+def generate_similarity(Xq, Xa, n_ans, svd):
+    Zq = svd.transform(Xq)
+    Za = svd.transform(Xa)
+    A = np.repeat(Zq, n_ans, axis=0)
+    B = Za
+    simZ = np.sum(A * B, axis=1) / (np.sqrt(np.sum(A * A, axis=1)) * np.sqrt(np.sum(B * B, axis=1)) + np.finfo(float).eps)
+    return simZ[:, np.newaxis]
+
+def generate_corr(Xq, Xa, n_ans, svd):
+    Zq = svd.transform(Xq)
+    Za = svd.transform(Xa)
+    A = np.repeat(Zq, n_ans, axis=0)
+    B = Za
+
+    corr = []
+    for a, b in zip(A,B):
+        corr.append(np.outer(a,b).flatten())
+
+    return np.vstack(corr)
+
+
 if __name__ == '__main__':
+    print('Main...')
     if len(sys.argv) != 3:
         raise Exception('Usage: python Main.py <data_dir> <ML/Heuristic>[0/1]')
     data_dir = sys.argv[1]
@@ -47,28 +70,30 @@ if __name__ == '__main__':
             print()
             
     else:
-        questions, answers, scores = get_raw_data_score(data_dir, n_ans, n_files=100)
-        Xq, Xa, feature_names = transform_raw_data(questions, answers)
+        questions, answers, scores = get_raw_data_score(data_dir, n_ans, n_files=102)
+        print('Data Loaded.')
+
+        Xq, Xa, feature_names = transform_raw_data(questions, answers, remove_tag=True)
         feature_names.append('correlation qa')
+        print('Data transformed')
 
         Y = reguralize_score(scores, n_ans)
 
         Xqtr, Xatr, Ytr, Xqte, Xate, Yte = split_data(Xq, Xa, Y, n_ans)
+        print('Data Splitted')
 
-        svd = TruncatedSVD(n_components=100)
+        svd = TruncatedSVD(n_components=30)
         Xqatr = sp.sparse.vstack((Xqtr, Xatr))
         svd.fit(Xqatr)
+        print('svd fitted')
 
-        Zqtr = svd.transform(Xqtr)
-        Zatr = svd.transform(Xatr)
-        A = np.repeat(Zqtr, n_ans, axis=0)
-        B = Zatr
-        simZtr = np.sum(A * B, axis=1) / (np.sqrt(np.sum(A * A, axis=1)) * np.sqrt(np.sum(B * B, axis=1)) + np.finfo(float).eps)
-
-        Zqte = svd.transform(Xqte)
-        Zate = svd.transform(Xate)
-        simZte = np.sum(np.repeat(Zqte, n_ans, axis=0) * Zate, axis=1)
-
+        # simZtr = generate_similarity(Xqtr, Xatr, n_ans, svd)
+        # simZte = generate_similarity(Xqte, Xate, n_ans, svd)
+        print('Xqatr', Xqatr.shape)
+        simZtr = generate_corr(Xqtr, Xatr, n_ans, svd)
+        simZte = generate_corr(Xqte, Xate, n_ans, svd)
+        print('simZtr.shape', simZtr.shape)
+        print('Sim generated')
 
         models = {
             'Logistic Regression': LogisticRegressionWrapper(n_ans=n_ans, penalty='l2', fit_intercept='True'),
@@ -81,13 +106,17 @@ if __name__ == '__main__':
         # NOTE: Non-Linear SVM is not scalable
         # On top of that, Linear SVM is supposed to be enough for this high dimensional features
 
-        use_cach = True
+        use_cach = False
+
+        print(Xatr.shape)
+        Xtr = sp.sparse.hstack((Xatr, simZtr))
+        print(Xtr.shape)
+        Xte = sp.sparse.hstack((Xate, simZte))
 
         for name, model in models.items():
-            # Xtr = sp.sparse.hstack((Xatr, simZtr[:, np.newaxis]))
-            # Xte = sp.sparse.hstack((Xate, simZte[:, np.newaxis]))
-            Xtr = Xatr
-            Xte = Xate
+
+            # Xtr = Xatr
+            # Xte = Xate
 
             if use_cach:
                 model = load_model(name, data_dir)
@@ -106,21 +135,6 @@ if __name__ == '__main__':
             print('test set accuracy:    ', prec_at_1(score_ans_te, Yte, n_ans))
             print('high score feature:\n', sorted_features[:20])
             print('low score feature :\n', sorted_features[-20:])
-            print()
-
-            model2 = LogisticRegressionWrapper(n_ans=n_ans, penalty='l2', fit_intercept='True')
-            Xtr2 = np.hstack((score_ans_tr[:, np.newaxis], simZtr[:, np.newaxis]))
-            Xte2 = np.hstack((score_ans_te[:, np.newaxis], simZte[:, np.newaxis]))
-
-            model2.fit(Xtr2, Ytr)
-
-            score_te = model2.predict_score(Xte2)
-            score_tr = model2.predict_score(Xtr2)
-    
-            print('- merge qa correlation -')
-            print('training set accuracy:', prec_at_1(score_tr, Ytr, n_ans))
-            print('test set accuracy:    ', prec_at_1(score_te, Yte, n_ans))
-            print('coef', model2.coef_)
             print()
 
     print('done')


### PR DESCRIPTION
LSA with outer product of QA

It didn't work well at all.
But just to merge at this time.

```
Running /Users/bigsea/PycharmProjects/cs175_project/bapred/Main.py
Main...
Data Loaded.
Data transformed
Data Splitted
svd fitted
Xqatr (495756, 616)
simZtr.shape (413130, 900)
Sim generated
(413130, 616)
(413130, 1516)
-- Logistic Regression --
training set accuracy: 0.324631471934
test set accuracy:     0.310423701122
high score feature:
 [(2.0210350531057966, 'edit'), (1.7834260837630207, 'note'), (1.2221147223081708, 'update'), (1.109528701842057, 'jsfiddle'), (1.0443171498790791, 'equivalent'), (0.92148978425946348, 'finally'), (0.91784726703835418, 'instead'), (0.90988149973328247, 'fact'), (0.85714511470089427, 'll'), (0.85684329640056045, 'documentation'), (0.85611670529015482, 'fix'), (0.82856335701011596, 'expression'), (0.82485207199986776, 'requires'), (0.8191507023340675, 'gt'), (0.80743965485341862, 'yes'), (0.79039041315641867, 'import'), (0.77623428739194533, 'standard'), (0.77210435343201766, 'gives'), (0.76884478503311293, 'developer'), (0.75490690386408943, 'foo')]
low score feature :
 [(-0.41432488421767322, 'wanted'), (-0.43675656426381182, 'similar'), (-0.44957734490846563, 'assume'), (-0.45891027593628636, 'did'), (-0.50323977192649139, 'believe'), (-0.51645710772107989, 'solution'), (-0.54026282009419457, 'worked'), (-0.64467089737657857, 'depends'), (-0.66506333367570913, 'know'), (-0.72272012107396133, 'mentioned'), (-0.74468438708774676, 'guess'), (-0.7509625799424644, 'said'), (-0.76491268360707187, 'answer'), (-0.77907029368910197, 'thought'), (-0.79405869337487833, 'maybe'), (-0.81543463523705384, 'hope'), (-0.85914599952425763, 'think'), (-0.87550350215887285, 'tried'), (-1.1636460099750261, 'correlation qa'), (-1.689293623570423, 'answers')]
```